### PR TITLE
Sync substack-milestone with latest chart updates

### DIFF
--- a/substack-milestone/index.html
+++ b/substack-milestone/index.html
@@ -7,7 +7,7 @@
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #fff; padding: 16px 32px 0; }
   h2 { font-size: 13px; color: #999; font-weight: 500; margin-bottom: 12px; letter-spacing: 0.08em; text-transform: uppercase; }
-  .cards { display: flex; gap: 16px; margin-bottom: 8px; }
+  .cards { display: flex; gap: 16px; margin-bottom: 8px; max-width: 1100px; }
   .card { flex: 1; border: 1px solid #e8e8e8; border-radius: 12px; padding: 20px 24px; position: relative; }
   .card .label { font-size: 13px; color: #888; margin-bottom: 6px; }
   .card .value { font-size: 34px; font-weight: 700; color: #111; }
@@ -108,7 +108,7 @@ function draw() {
   svg.selectAll("*").remove();
 
   const cardsBottom = document.querySelector('.cards').getBoundingClientRect().bottom;
-  const margin = { top: 16, right: 30, bottom: 36, left: 52 };
+  const margin = { top: 16, right: 8, bottom: 36, left: 0 };
   const totalW = Math.min(document.documentElement.clientWidth - 64, 1100);
   const width  = totalW - margin.left - margin.right;
   const chartH = Math.max(250, window.innerHeight - cardsBottom - margin.top - margin.bottom - 8);
@@ -142,8 +142,11 @@ function draw() {
     .call(d3.axisBottom(x).ticks(d3.timeMonth.every(1)).tickFormat(fmtMonth).tickSize(0).tickPadding(10))
     .call(a => a.select(".domain").remove());
   g.append("g").attr("class","axis")
-    .call(d3.axisLeft(y).ticks(5).tickSize(0).tickPadding(8))
-    .call(a => a.select(".domain").remove());
+    .call(d3.axisLeft(y).ticks(5).tickSize(0).tickPadding(4))
+    .call(a => {
+      a.select(".domain").remove();
+      a.selectAll("text").attr("x", 4).attr("text-anchor","start").attr("dy","-0.3em");
+    });
 
   g.append("a").attr("href","https://alyssafuward.substack.com").attr("target","_blank").style("cursor","pointer")
     .append("text").attr("class","watermark")


### PR DESCRIPTION
## Summary
- Flushes chart left edge with stat cards (margin.left=0, y-axis labels float inside chart)
- Moves info ⓘ button to title bar next to Substack link
- Clamps pins below the 500 gridline
- Responsive resize via debounced draw()

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)