### PR TITLE
Rename First Comments → First Replies (#22)

### DIFF
--- a/first-replies/index.html
+++ b/first-replies/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>First Comments — alyssafuward.substack.com</title>
+<title>First Replies — alyssafuward.substack.com</title>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='13' fill='%23E07A10' stroke='white' stroke-width='3'/></svg>">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -102,7 +102,7 @@
 </style>
 </head>
 <body>
-<h2>First Comments · <a href="https://alyssafuward.substack.com" target="_blank" style="color:inherit;text-decoration:none;border-bottom:1px solid #ddd;">alyssafuward.substack.com</a> · Thank you for commenting<span id="info-btn" title="About this data">ⓘ</span><button id="nav-toggle">all commenters ▾</button></h2>
+<h2>First Replies · <a href="https://alyssafuward.substack.com" target="_blank" style="color:inherit;text-decoration:none;border-bottom:1px solid #ddd;">alyssafuward.substack.com</a> · Thank you for commenting<span id="info-btn" title="About this data">ⓘ</span><button id="nav-toggle">all commenters ▾</button></h2>
 <div class="cards">
   <div class="card">
     <div class="label">Total subscribers</div>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     <p class="sub">Things that happened on the internet</p>
     <div class="links">
       <a class="btn" href="./orange-story/">🍊 The Orange Story →</a>
-      <a class="btn" href="./first-comments/">📈 First Comments →</a>
+      <a class="btn" href="./first-replies/">📈 First Replies →</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- Renames the visualization from "First Comments" to "First Replies" everywhere it appears
- Moves folder from `first-comments/` → `first-replies/` (URL changes to `/first-replies/`)
- Updates home page button link and label
- Updates `<title>` tag and h2 heading inside the viz

Note: this branch is based on `feat/20-filter-foreign-commenters` so it includes those filter changes too. Merge PR #21 first, then this one.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)